### PR TITLE
Dont run when in building phase

### DIFF
--- a/docker-args
+++ b/docker-args
@@ -7,7 +7,7 @@ DOCKER_OPTIONS_FILE="DOCKER_OPTIONS"
 DOCKER_OPTIONS_FILE_PATH="$DOKKU_ROOT/$APP/$DOCKER_OPTIONS_FILE"
 
 output=""
-if [[ -f "$DOCKER_OPTIONS_FILE_PATH" ]]; then
+if [[ -f "$DOCKER_OPTIONS_FILE_PATH" ]] && [[ "$PHASE" != "build" ]]; then
   DONE=false
   until $DONE; do
     read line || DONE=true


### PR DESCRIPTION
Hi!

Took some hours of debugging and googling to find out why docker-options failed on dokku v0.3.15.

The same issue as in dyson/dokku-persistent-storage#12, this PR contains the exact same change as fixed it in dyson/dokku-persistent-storage: dyson/dokku-persistent-storage@c61bcfa062aa6729d8c40f2a6ddc51d587fbd6a4
